### PR TITLE
fix(#502): Toast with 100% width

### DIFF
--- a/src/components/Toast/styles.module.scss
+++ b/src/components/Toast/styles.module.scss
@@ -38,6 +38,11 @@
   display: flex;
   flex-direction: column-reverse;
   gap: var(--spaces-2);
+  background-color: transparent !important;
+
+  @include temporary-mobile {
+    right: var(--spaces-2);
+  }
 }
 
 .wrapper {
@@ -79,8 +84,7 @@
   }
 
   @include mobile {
-    left: 50%;
-    width: calc(100% - var(--spaces-2) * 2);
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Dependendo do width do toast ainda ficava cortado para fora da tela no mobile, se a mensagem fosse maior do que no exemplo do storybook por exemplo.
Achei um exemplo do toast do mobile no figma e ele fica com 100% quando a mensagem é grande, mudei então para quando for mobile ficar igual

| Figma |
| --- |
| ![image](https://github.com/user-attachments/assets/d18ce724-0b63-40ba-a211-e837b292e733) |

## Antes


https://github.com/user-attachments/assets/d8188db2-05ef-49ad-acba-58cbc60ed880

https://github.com/user-attachments/assets/223b327b-154f-4257-bb9d-977a670b967d




## Depois
https://github.com/user-attachments/assets/1492e8db-d2f0-4618-b52d-c59e7ffc4cc6

https://github.com/user-attachments/assets/386f47ba-1509-47f4-a3dd-2ab1745a75e0


