### PR TITLE
feat(#188): Adicionar suporte ao darkmode em componentes utilizados na tela "Início" do admin.

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "./index";
+import React from "react";
 
 const meta = {
   component: Button,
@@ -9,6 +10,24 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+
+const Template: Story = {
+  render: ({ children, ...args }) => (
+    <div>
+      <div className="light-theme" style={{ marginBottom: "1rem" }}>
+        <h2>Light Theme</h2>
+        <Button {...args}>{children}</Button>
+      </div>
+      <div className="dark-theme">
+        <h2>Dark Theme</h2>
+        <div style={{ background: "black", width: "max-content", padding: 5 }}>
+          <Button {...args}>{children}</Button>
+        </div>
+      </div>
+    </div>
+  ),
+};
 
 export const Default: Story = {
   args: {
@@ -33,6 +52,7 @@ export const Tertiary: Story = {
 };
 
 export const Outline: Story = {
+  ...Template,
   args: {
     name: "Button Ouline",
     variant: "outline",
@@ -61,3 +81,4 @@ export const Text: Story = {
     children: "Text",
   },
 };
+

--- a/src/components/Button/variants.module.scss
+++ b/src/components/Button/variants.module.scss
@@ -133,13 +133,17 @@
   transition:
     box-shadow 0.3s,
     background-color 0.3s;
-  will-change: box-shadow, background-color;
-
+    will-change: box-shadow, background-color;
+  :global(.dark-theme) & {
+    background-color: var(--colors-dark-gray-900) !important;
+    color: var(--colors-dark-gray-500) !important;
+    border-color: var(--colors-dark-gray-500) !important;
+  }
   &:hover:not(:disabled):not(:active) {
     background: var(--colors-gray-100) !important;
 
     :global(.dark-theme) & {
-      background-color: var(--colors-dark-gray-700) !important;
+      background-color: var(--colors-dark-gray-500) !important;
     }
   }
 

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -11,14 +11,30 @@ export default {
 } as Meta<TriggerProps>;
 
 const Template: StoryFn = () => (
-  <Dropdown.Container>
-    <Dropdown.Trigger>Open Dropdown</Dropdown.Trigger>
-    <Dropdown.Menu>
-      <Dropdown.Item>Item 1</Dropdown.Item>
-      <Dropdown.Item>Item 2</Dropdown.Item>
-      <Dropdown.Item>Item 3</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown.Container>
+  <div>
+      <div className="dark-theme">
+        <h2>Dark Theme</h2>
+        <Dropdown.Container>
+          <Dropdown.Trigger>Open Dropdown</Dropdown.Trigger>
+          <Dropdown.Menu>
+            <Dropdown.Item>Item 1</Dropdown.Item>
+            <Dropdown.Item>Item 2</Dropdown.Item>
+            <Dropdown.Item>Item 3</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown.Container>
+      </div>
+      <div className="light-theme">
+        <h2>Light Theme</h2>
+        <Dropdown.Container>
+          <Dropdown.Trigger>Open Dropdown</Dropdown.Trigger>
+          <Dropdown.Menu>
+            <Dropdown.Item>Item 1</Dropdown.Item>
+            <Dropdown.Item>Item 2</Dropdown.Item>
+            <Dropdown.Item>Item 3</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown.Container>
+      </div>
+  </div>
 );
 
 export const Default = Template.bind({});

--- a/src/components/Dropdown/Item/styles.module.scss
+++ b/src/components/Dropdown/Item/styles.module.scss
@@ -22,7 +22,10 @@
   border: none;
   background-color: transparent;
   cursor: pointer;
-
+  :global(.dark-theme) & {
+    background-color: var(--colors-dark-gray-700) !important;
+    color: var(--colors-gray-300) !important;
+  }
   & * {
     figure,
     svg {
@@ -31,5 +34,8 @@
   }
   &:hover {
     background-color: var(--highlight-dropdown-selected-item);
+    :global(.dark-theme) & {
+      background-color: var(--colors-dark-gray-600) !important;
+    }
   }
 }

--- a/src/components/Dropdown/Menu/index.tsx
+++ b/src/components/Dropdown/Menu/index.tsx
@@ -9,13 +9,30 @@ export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
 const Menu = forwardRef<HTMLDivElement, MenuProps>(
   ({ children, className, ...props }, ref) => {
     return (
-      <div
-        ref={ref}
-        className={concatStyles([styles.menu, className])}
-        {...props}
-      >
-        {children}
-      </div>
+      <div>
+        <div className="light-theme" style={{ marginBottom: "1rem" }}>
+          <h2>Light Theme</h2>
+            <div
+              ref={ref}
+              className={concatStyles([styles.menu, className])}
+              {...props}
+            >
+              {children}
+          </div>
+        </div>
+        <div className="dark-theme" style={{ marginTop: 250 }}>
+          <h2>Dark Theme</h2>
+          <div style={{ background: "black", width: "max-content" }}>
+            <div
+              ref={ref}
+              className={concatStyles([styles.menu, className])}
+              {...props}
+            >
+              {children}
+            </div>
+          </div>
+        </div>
+    </div>
     );
   },
 );

--- a/src/components/Dropdown/Menu/styles.module.scss
+++ b/src/components/Dropdown/Menu/styles.module.scss
@@ -25,4 +25,7 @@
   align-items: flex-start;
   gap: var(--spaces-micro);
   max-width: fit-content;
+  :global(.dark-theme) & {
+    background-color: var(--colors-dark-gray-700) !important;
+  }
 }

--- a/src/components/Dropdown/Trigger/styles.module.scss
+++ b/src/components/Dropdown/Trigger/styles.module.scss
@@ -12,8 +12,15 @@
   background-color: var(--trigger-background);
   transition: background-color 0.3s ease-in-out;
   padding: 0 var(--spaces-2);
-
+  :global(.dark-theme) & {
+    background-color: var(--colors-dark-gray-900) !important;
+    color: var(--colors-dark-gray-500) !important;
+    border-color: var(--colors-dark-gray-500) !important;
+  }
   &:hover {
     background: var(--colors-gray-50);
+    :global(.dark-theme) & {
+      background-color: var(--colors-dark-gray-600) !important;
+    }
   }
 }


### PR DESCRIPTION
[Adicionar suporte ao darkmode em componentes utilizados na tela "Início" do admin](https://github.com/splitwave-br/design-system-splitwave/issues/188)

Essa task está relacionada a [Task Implementação do Darkmode no admin-splitwave](https://github.com/splitwave-br/admin-splitwave/issues/734)