### PR TITLE
fix(badges-colors): added correct color on badge gray

### DIFF
--- a/dist/components/Badge/variables.scss
+++ b/dist/components/Badge/variables.scss
@@ -1,7 +1,7 @@
 .light-theme {
     //Gray
     --component-badge-gray-text: var(--colors-dark-gray-700);
-    --component-badge-gray-background: var(--colors-gray-300);
+    --component-badge-gray-background: var(--colors-light-gray-300);
 
     // Orange
     --component-badge-orange-background: var(--colors-orange-300);

--- a/dist/components/Badge/variables.scss
+++ b/dist/components/Badge/variables.scss
@@ -1,7 +1,7 @@
 .light-theme {
     //Gray
     --component-badge-gray-text: var(--colors-dark-gray-700);
-    --component-badge-gray-background: var(--colors-dark-gray-400);
+    --component-badge-gray-background: var(--colors-gray-300);
 
     // Orange
     --component-badge-orange-background: var(--colors-orange-300);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "copy-files": "copyfiles -u 1 \"src/**/*.scss\" dist",
+    "copy-files": "copyfiles -u 1 'src/**/*.scss' dist",
     "declaration": "npx tsc --declaration",
     "build": "yarn clean && yarn declaration && tsc && tsc-alias && yarn copy-files",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist/",
-    "copy-files": "copyfiles -u 1 'src/**/*.scss' dist",
+    "copy-files": "copyfiles -u 1 \"src/**/*.scss\" dist",
     "declaration": "npx tsc --declaration",
     "build": "yarn clean && yarn declaration && tsc && tsc-alias && yarn copy-files",
     "storybook": "storybook dev -p 6006",

--- a/src/components/Badge/variables.scss
+++ b/src/components/Badge/variables.scss
@@ -1,7 +1,7 @@
 .light-theme {
     //Gray
     --component-badge-gray-text: var(--colors-dark-gray-700);
-    --component-badge-gray-background: var(--colors-gray-300);
+    --component-badge-gray-background: var(--colors-light-gray-300);
 
     // Orange
     --component-badge-orange-background: var(--colors-orange-300);

--- a/src/components/Badge/variables.scss
+++ b/src/components/Badge/variables.scss
@@ -1,7 +1,7 @@
 .light-theme {
     //Gray
     --component-badge-gray-text: var(--colors-dark-gray-700);
-    --component-badge-gray-background: var(--colors-dark-gray-400);
+    --component-badge-gray-background: var(--colors-gray-300);
 
     // Orange
     --component-badge-orange-background: var(--colors-orange-300);


### PR DESCRIPTION
Marcus solicitou que fosse feito uma alteração no background da variant "gray" apenas no modo light:
![image](https://github.com/user-attachments/assets/68fcd55b-4f4b-4c29-8c51-12cf137ebf55)
![image](https://github.com/user-attachments/assets/2f819a51-2e63-48b0-8931-641b64a69c26)

Resultado:
![image](https://github.com/user-attachments/assets/bb155577-1f7b-4c3b-8eda-fc4f6c73f0bc)
