### PR TITLE
feat(#319): add unique id to checkbox component

### DIFF
--- a/dist/components/Form/controls/Checkbox/index.js
+++ b/dist/components/Form/controls/Checkbox/index.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useId } from "react";
 import styles from "./styles.module.scss";
 import { concatStyles } from "../../../../utils/concatStyles";
 import Checked from "../../../Filter/components/Checkboxes/components/Checked";
@@ -7,12 +7,13 @@ import Unchecked from "../../../Filter/components/Checkboxes/components/Unchecke
 export var Checkbox = forwardRef(function (_a, ref) {
     var label = _a.label, onChange = _a.onChange, value = _a.value;
     var isChecked = value;
+    var randomId = useId();
     return (_jsx(React.Fragment, { children: _jsx("div", { onClick: function (e) {
                 e.stopPropagation();
                 onChange();
-            }, children: _jsxs("label", { htmlFor: label, className: styles.field, children: [_jsxs("div", { className: concatStyles([
+            }, children: _jsxs("label", { htmlFor: randomId, className: styles.field, children: [_jsxs("div", { className: concatStyles([
                             styles.inputWrapper,
                             isChecked ? styles.isChecked : "",
-                        ]), children: [_jsx("input", { className: styles.checkbox, type: "checkbox", id: label, ref: ref, onChange: onChange, checked: isChecked }), isChecked ? _jsx(Checked, {}) : _jsx(Unchecked, {})] }), label && _jsx("span", { className: styles.label, children: label })] }) }) }, label));
+                        ]), children: [_jsx("input", { className: styles.checkbox, type: "checkbox", id: randomId, ref: ref, onChange: onChange, checked: isChecked }), isChecked ? _jsx(Checked, {}) : _jsx(Unchecked, {})] }), label && _jsx("span", { className: styles.label, children: label })] }) }) }, randomId));
 });
 Checkbox.displayName = "Checkbox";

--- a/src/components/Form/controls/Checkbox/index.tsx
+++ b/src/components/Form/controls/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef, useId, useState } from "react";
 import styles from "./styles.module.scss";
 
 import { concatStyles } from "@/utils/concatStyles";
@@ -14,16 +14,17 @@ type CheckboxProps = {
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ label, onChange, value }, ref) => {
     const isChecked = value;
+    const randomId = useId();
 
     return (
-      <React.Fragment key={label}>
+      <React.Fragment key={randomId}>
         <div
           onClick={(e) => {
             e.stopPropagation();
             onChange();
           }}
         >
-          <label htmlFor={label} className={styles.field}>
+          <label htmlFor={randomId} className={styles.field}>
             <div
               className={concatStyles([
                 styles.inputWrapper,
@@ -33,7 +34,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               <input
                 className={styles.checkbox}
                 type="checkbox"
-                id={label}
+                id={randomId}
                 ref={ref}
                 onChange={onChange}
                 checked={isChecked}


### PR DESCRIPTION
[link da task](https://github.com/splitwave-br/design-system-splitwave/issues/319)


### Descrição

Antes o componente de checkbox usava sua própria label como id

Agora o react fica responsavel por gerar id's unicos para garantir que nao vai haver conflitos