### PR TITLE
fix(#filter-checkbox): adjusted label color

### DIFF
--- a/dist/components/Filter/components/Checkboxes/styles.module.scss
+++ b/dist/components/Filter/components/Checkboxes/styles.module.scss
@@ -55,7 +55,7 @@
   }
 
   .label {
-    color: var(--primary-text);
+    color: var(--colors-font-primary);
 
     font-size: var(--font-size-3);
     font-weight: 500;

--- a/src/components/Filter/components/Checkboxes/styles.module.scss
+++ b/src/components/Filter/components/Checkboxes/styles.module.scss
@@ -55,7 +55,7 @@
   }
 
   .label {
-    color: var(--primary-text);
+    color: var(--colors-font-primary);
 
     font-size: var(--font-size-3);
     font-weight: 500;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d032aef5-6fef-4908-8c09-32a347f37dd4)
![image](https://github.com/user-attachments/assets/38a0af98-548c-4779-bc0d-ecf5df7c29b2)

Antes: Estava com cor gray-900 em ambos temas.
Agora: Tem suporte dark.